### PR TITLE
Feature/assoc req

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 ideas
+.vscode/
+.DS_Store
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -75,6 +77,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+*.ipynb
 
 # IPython
 profile_default/

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -28,14 +28,16 @@ def assoc_req_parse(frame):
         frame.getlayer(Dot11Elt, ID=0).info.decode("utf-8") == SSID):
         client_mac = frame.addr2
         bssid = frame.addr3
+        
+        supported_channels = supported_channels_parse(frame)
 
         print(f"Client {client_mac} sent Assoc Req to BSSID {bssid}")
         print("Supported channels")
-        print(*supported_channels_parse(frame), sep = ", ")
+        print(*supported_channels, sep = ", ")
 
 def main():
     print("####Catching Association Request####")
-    sniff(iface=INTERFACE, prn=assoc_req_parse, store=0)
+    sniff(iface=INTERFACE, filter="type mgt subtype assoc-req", prn=assoc_req_parse, store=0)
 
 if __name__ == '__main__':
     main()

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -7,25 +7,31 @@ from scapy.all import *
 INTERFACE = "wlan0"
 SSID = "lab-iap"
 
+def supported_channels_parse(frame):
+    # Convert info field of the IE (b'' string) to hex
+    channels_raw = frame.getlayer(Dot11Elt, ID=36).info.hex()
+    supported_channels = []
+    # IEEE802.11 defines the following format for supported channels:
+    # 1 byte (2 hex digits) for 'first channel number'
+    # 1 byte (2 hex digits) for 'number of channels'
+    for i in range(0, len(channels_raw), 4):
+        tmp = channels_raw[i:i+4]
+        first_channel = int(tmp[:2], 16)
+        num_of_channels = int(tmp[2:], 16)
+        supported_channels.extend(
+            [first_channel+num_of_channels*i for i in range(0, num_of_channels)])
+    
+    return supported_channels    
+
 def assoc_req_parse(frame):
-    if frame.haslayer(Dot11AssoReq) and frame.getlayer(Dot11Elt, ID=0).info.decode("utf-8") == SSID:
+    if (frame.haslayer(Dot11AssoReq) and 
+        frame.getlayer(Dot11Elt, ID=0).info.decode("utf-8") == SSID):
         client_mac = frame.addr2
         bssid = frame.addr3
-        # Convert info field of the IE (b'' string) to hex
-        channels_raw = frame.getlayer(Dot11Elt, ID=36).info.hex()
-        supported_channels = []
-        # IEEE802.11 defines the following format for supported channels:
-        # 1 byte (2 hex digits) for 'first channel number'
-        # 1 byte (2 hex digits) for 'number of channels'
-        for i in range(0, len(channels_raw), 4):
-            tmp = channels_raw[i:i+4]
-            first_channel = int(tmp[:2], 16)
-            num_of_channels = int(tmp[2:], 16)
-            supported_channels.extend([first_channel+num_of_channels*i for i in range(0, num_of_channels)]) 
 
         print(f"Client {client_mac} sent Assoc Req to BSSID {bssid}")
         print("Supported channels")
-        print(*supported_channels, sep = ", ")
+        print(*supported_channels_parse(frame), sep = ", ")
 
 def main():
     print("####Catching Association Request####")

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -1,3 +1,5 @@
+import logging
+import sys
 from scapy.all import *
 
 # Check whether a wireless adapter is in monitor mode.
@@ -5,8 +7,15 @@ from scapy.all import *
 # adapter to a monitor mode.
 
 INTERFACE = "wlan0"
-SSID = "lab-iap"
-assoc_req_file = "assoc_req.pcap"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.FileHandler("debug.log"),
+        logging.StreamHandler(sys.stdout)
+    ]
+)
 
 def write_pcap(frame, pcap_file = "assoc_req.pcap"):
     wrpcap(pcap_file, frame, append=True, sync=True)
@@ -33,20 +42,19 @@ def supported_channels_parse(frame):
         return supported_channels   
 
 def assoc_req_parse(frame):
-    write_pcap(frame, assoc_req_file)
+    write_pcap(frame)
     ssid = frame.getlayer(Dot11Elt, ID=0).info.decode("utf-8")
     client_mac = frame.addr2
     bssid = frame.addr3
     
     supported_channels = supported_channels_parse(frame)
 
-    print(f"AssocReq, Client {client_mac}, BSSID {bssid}, SSID {ssid}")
-    print("Supported channels")
-
+    message = f"AssocReq, Client {client_mac}, BSSID {bssid}, SSID {ssid}"
     if not supported_channels:
-        print("No info")
+        message1 = "Supported channels: No Info"
     else:
-        print(*supported_channels, sep = ", ")
+        message1 = f"Supported channels: {supported_channels}"
+    logging.info(message + ", " + message1)
 
 def main():
     print("####Catching Association Request####")
@@ -54,4 +62,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -8,24 +8,27 @@ INTERFACE = "wlan0"
 SSID = "lab-iap"
 
 def supported_channels_parse(frame):
-    # Convert info field of the IE (b'' string) to hex
-    channels_raw = frame.getlayer(Dot11Elt, ID=36).info.hex()
     supported_channels = []
-    # IEEE802.11 defines the following format for supported channels:
-    # 1 byte (2 hex digits) for 'first channel number'
-    # 1 byte (2 hex digits) for 'number of channels'
-    for i in range(0, len(channels_raw), 4):
-        tmp = channels_raw[i:i+4]
-        first_channel = int(tmp[:2], 16)
-        num_of_channels = int(tmp[2:], 16)
-        supported_channels.extend(
-            [first_channel+num_of_channels*i for i in range(0, num_of_channels)])
     
-    return supported_channels    
+    try:
+        # Convert info field of the IE (b'' string) to hex
+        channels_raw = frame.getlayer(Dot11Elt, ID=36).info.hex()
+        # IEEE802.11 defines the following format for supported channels:
+        # 1 byte (2 hex digits) for 'first channel number'
+        # 1 byte (2 hex digits) for 'number of channels'
+        for i in range(0, len(channels_raw), 4):
+            tmp = channels_raw[i:i+4]
+            first_channel = int(tmp[:2], 16)
+            num_of_channels = int(tmp[2:], 16)
+            supported_channels.extend(
+                [first_channel+num_of_channels*i for i in range(0, num_of_channels)])
+
+        return supported_channels
+    except AttributeError:
+        # Return an empty list of supported channels if a client doesn't advertise them
+        return supported_channels   
 
 def assoc_req_parse(frame):
-    if (frame.haslayer(Dot11AssoReq) and 
-        frame.getlayer(Dot11Elt, ID=0).info.decode("utf-8") == SSID):
         client_mac = frame.addr2
         bssid = frame.addr3
         
@@ -33,7 +36,11 @@ def assoc_req_parse(frame):
 
         print(f"Client {client_mac} sent Assoc Req to BSSID {bssid}")
         print("Supported channels")
-        print(*supported_channels, sep = ", ")
+
+        if not supported_channels:
+            print("No info")
+        else:
+            print(*supported_channels, sep = ", ")
 
 def main():
     print("####Catching Association Request####")

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -10,14 +10,13 @@ also written to a pcap file for further investigation.
 
 import logging
 import sys
+# It's bad to do wildcard imports. There should be a better way.
 from scapy.all import *
 
-# Check whether a wireless adapter is in monitor mode.
-# Can be done using a function from module that sets
-# adapter to a monitor mode.
-
+# Use adapter_control module to set interface.
 INTERFACE = "wlan0"
 
+# Logging should be implemented better (system wide logging module)
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -69,7 +68,7 @@ def assoc_req_parse(frame):
 
 def main():
     print("####Catching Association Request####")
-    sniff(iface=INTERFACE, filter="type mgt subtype assoc-req",
+    sniff(iface=INTERFACE, monitor=True, filter="type mgt subtype assoc-req",
           prn=assoc_req_parse, store=0)
 
 

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -4,13 +4,18 @@ from scapy.all import *
 # Can be done using a function from module that sets
 # adapter to a monitor mode.
 
-#def assoc_req(frame):
-    #if frame.haslayer(Dot11AssoReq):
-        #print('Association Request')
-
 def assoc_req_parse(frame):
     print(frame.addr2)
 
-sniff(iface='wlan0', lfilter = lambda x: x.haslayer(Dot11AssoReq), prn=assoc_req_parse, store=0)
+#sniff(iface='wlan0', lfilter = lambda x: x.haslayer(Dot11AssoReq), prn=assoc_req_parse, store=0)
 #s = AsyncSniffer(iface="wlan0", lfilter = lambda x: x.haslayer(Dot11AssoReq), prn=assoc_req_parse)
+
+def sniff(interface, func):
+    sniff(iface=interface, prn=func, store=0)
+
+def main():
+    sniff(wlan0, assoc_req_parse)
+
+if __name__ == '__main__':
+    main()
 

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -24,7 +24,8 @@ def assoc_req_parse(frame):
             supported_channels.extend([first_channel+num_of_channels*i for i in range(0, num_of_channels)]) 
 
         print(f"Client {client_mac} sent Assoc Req to BSSID {bssid}")
-        print(supported_channels)
+        print("Supported channels")
+        print(*supported_channels, sep = ", ")
 
 def main():
     print("####Catching Association Request####")

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -29,18 +29,19 @@ def supported_channels_parse(frame):
         return supported_channels   
 
 def assoc_req_parse(frame):
-        client_mac = frame.addr2
-        bssid = frame.addr3
-        
-        supported_channels = supported_channels_parse(frame)
+    ssid = frame.getlayer(Dot11Elt, ID=0).info.decode("utf-8")
+    client_mac = frame.addr2
+    bssid = frame.addr3
+    
+    supported_channels = supported_channels_parse(frame)
 
-        print(f"Client {client_mac} sent Assoc Req to BSSID {bssid}")
-        print("Supported channels")
+    print(f"AssocReq, Client {client_mac}, BSSID {bssid}, SSID {ssid}")
+    print("Supported channels")
 
-        if not supported_channels:
-            print("No info")
-        else:
-            print(*supported_channels, sep = ", ")
+    if not supported_channels:
+        print("No info")
+    else:
+        print(*supported_channels, sep = ", ")
 
 def main():
     print("####Catching Association Request####")

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -7,6 +7,9 @@ from scapy.all import *
 INTERFACE = "wlan0"
 SSID = "lab-iap"
 
+def write_frame(frame):
+    wrpcap("assoc_req.pcap", frame, append=True, sync=True)
+
 def supported_channels_parse(frame):
     supported_channels = []
     
@@ -29,6 +32,7 @@ def supported_channels_parse(frame):
         return supported_channels   
 
 def assoc_req_parse(frame):
+    write_frame(frame)
     ssid = frame.getlayer(Dot11Elt, ID=0).info.decode("utf-8")
     client_mac = frame.addr2
     bssid = frame.addr3

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -4,17 +4,38 @@ from scapy.all import *
 # Can be done using a function from module that sets
 # adapter to a monitor mode.
 
+INTERFACE = "wlan0"
+SSID = "lab-iap"
+
 def assoc_req_parse(frame):
-    print(frame.addr2)
+    if frame.haslayer(Dot11AssoReq) and frame.getlayer(Dot11Elt, ID=0).info.decode("utf-8") == SSID:
+        client = frame.addr2
+        bssid = frame.addr3
+        channels_raw = frame.getlayer(Dot11Elt, ID=36).info.hex()
+        channels = {}
+        for i in range(0, len(channels_raw), 4):
+            tmp = channels_raw[i:i+4]
+            channel = int(tmp[:2], 16)
+            range_ = int(tmp[2:], 16)
+            channels[channel] = range_
+
+        print(f"Client {client} sent Assoc Req to BSSID {bssid}")
+        print("Channel : Range")
+        for i in channels:
+            print(f"{i} : {channels[i]}")
+
+    #return channels
 
 #sniff(iface='wlan0', lfilter = lambda x: x.haslayer(Dot11AssoReq), prn=assoc_req_parse, store=0)
 #s = AsyncSniffer(iface="wlan0", lfilter = lambda x: x.haslayer(Dot11AssoReq), prn=assoc_req_parse)
 
-def sniff(interface, func):
-    sniff(iface=interface, prn=func, store=0)
+#def sniff(interface, func):
+    #sniff(iface=interface, prn=func, store=0)
 
 def main():
-    sniff(wlan0, assoc_req_parse)
+    #sniff('wlan0', assoc_req_parse)
+    print("####Catching Association Request####")
+    sniff(iface=INTERFACE, prn=assoc_req_parse, store=0)
 
 if __name__ == '__main__':
     main()

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -1,0 +1,16 @@
+from scapy.all import *
+
+# Check whether a wireless adapter is in monitor mode.
+# Can be done using a function from module that sets
+# adapter to a monitor mode.
+
+#def assoc_req(frame):
+    #if frame.haslayer(Dot11AssoReq):
+        #print('Association Request')
+
+def assoc_req_parse(frame):
+    print(frame.addr2)
+
+sniff(iface='wlan0', lfilter = lambda x: x.haslayer(Dot11AssoReq), prn=assoc_req_parse, store=0)
+#s = AsyncSniffer(iface="wlan0", lfilter = lambda x: x.haslayer(Dot11AssoReq), prn=assoc_req_parse)
+

--- a/client_capabilities/assoc_req.py
+++ b/client_capabilities/assoc_req.py
@@ -6,9 +6,10 @@ from scapy.all import *
 
 INTERFACE = "wlan0"
 SSID = "lab-iap"
+assoc_req_file = "assoc_req.pcap"
 
-def write_frame(frame):
-    wrpcap("assoc_req.pcap", frame, append=True, sync=True)
+def write_pcap(frame, pcap_file = "assoc_req.pcap"):
+    wrpcap(pcap_file, frame, append=True, sync=True)
 
 def supported_channels_parse(frame):
     supported_channels = []
@@ -32,7 +33,7 @@ def supported_channels_parse(frame):
         return supported_channels   
 
 def assoc_req_parse(frame):
-    write_frame(frame)
+    write_pcap(frame, assoc_req_file)
     ssid = frame.getlayer(Dot11Elt, ID=0).info.decode("utf-8")
     client_mac = frame.addr2
     bssid = frame.addr3


### PR DESCRIPTION
Here a module for catching assoc req and parse it on the fly. Right now supported channels get parsed. Scapy doesn't provide an API to access supported channels so a simple dissector was added to accomplish it.